### PR TITLE
Use of GitHub Actions instead Travis for CI

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,4 +1,4 @@
-name: Java CI
+name: Build
 
 on: [push]
 
@@ -15,3 +15,7 @@ jobs:
         java-version: 1.8
     - name: Build with Maven
       run: mvn -B package --file pom.xml
+    - name: Upload code coverage
+      uses: codecov/codecov-action@v1
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,0 @@
-language: java
-jdk:
-  - oraclejdk8
-after_success:
-  - bash <(curl -s https://codecov.io/bash)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Mutants Detector
 
-[![Build Status](https://github.com/pferraris/mutants/workflows/Build/badge.svg)
+[![Build Status](https://github.com/pferraris/mutants/workflows/Build/badge.svg)](https://github.com/pferraris/mutants/actions?query=workflow%3A"Build")
 [![codecov](https://codecov.io/gh/pferraris/mutants/branch/master/graph/badge.svg)](https://codecov.io/gh/pferraris/mutants)
 
 API to detect mutants based on their DNA.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Mutants Detector
 
-[![Build Status](https://travis-ci.org/pferraris/mutants.svg?branch=master)](https://travis-ci.org/pferraris/mutants)
+[![Build Status](https://github.com/pferraris/mutants/workflows/Build/badge.svg)
 [![codecov](https://codecov.io/gh/pferraris/mutants/branch/master/graph/badge.svg)](https://codecov.io/gh/pferraris/mutants)
 
 API to detect mutants based on their DNA.


### PR DESCRIPTION
Deletes Travis configuration file.
Updates GitHub Workflow for uploading code coverage to codecov.
Replaces build badge